### PR TITLE
Some changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Cook Time: {{prettyTime cookTime}}
 Total Time: {{prettyTime totalTime}}
 ```
 
+`savedAt`
+Timestamp when recipe is saved to Obsidian. Supports masks available at [dateformat](https://www.npmjs.com/package/dateformat).
+Defaults to `yyyy-mm-dd HH:MM`
+
+```
+Saved: {{savedAt}}
+Time: {{savedAt "HH:MM"}}
+Date: {{savedAt "yyyy-mm-dd"}}
+```
+
 ---
 
 In the meantime, I did my best to make the most recipes I can work out of the box. Please [create ticket](#) if you have suggestions for improving it!

--- a/README.md
+++ b/README.md
@@ -14,14 +14,16 @@ If you have this problem, go to the settings of this plugin and remove the leadi
 
 ### Settings
 
-- Save Image: Downloads the recipe image into the vault (save location can be set in the plugin settings). `{{image}}` value will be the link to the downloaded file instead of the direct URL. Disabled by default. If Save Image option is enabled, use `![[{{image}}]]` in the template.
->if settings is toggled off or image save fails, `{{image}}` value will be a direct URL.
+-   Save Image: Downloads the recipe image into the vault (save location can be set in the plugin settings). `{{image}}` value will be the link to the downloaded file instead of the direct URL. Disabled by default. If Save Image option is enabled, use `![[{{image}}]]` in the template.
+    > if settings is toggled off or image save fails, `{{image}}` value will be a direct URL.
 
 ### Custom templating
 
 Prefer your own layout instead? No problem. Just paste a [custom handlebars string template](https://handlebarsjs.com/guide/#simple-expressions) into the settings.
 
 We're assuming the page has a [json recipe](https://developers.google.com/search/docs/appearance/structured-data/recipe#guided-example) on the page. Make sure to check the [Example Recipe](https://developers.google.com/search/docs/appearance/structured-data/recipe#guided-example) for a list of what fields you can pull. And keep in mind that lots of recipes seem to not stick exactly to the spec. So expect some thing to take a little extra effort to get them there.
+
+A custom handlebar function to split comma separated tags is available, as Obsidian expect tags as a list in its properties. The function is called `splitTags`, and could be used as this in a template: `{{splitTags keywords}}`.
 
 You can also add `{{{json}}}` for the raw json in the template if you like.
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,26 @@ Prefer your own layout instead? No problem. Just paste a [custom handlebars stri
 
 We're assuming the page has a [json recipe](https://developers.google.com/search/docs/appearance/structured-data/recipe#guided-example) on the page. Make sure to check the [Example Recipe](https://developers.google.com/search/docs/appearance/structured-data/recipe#guided-example) for a list of what fields you can pull. And keep in mind that lots of recipes seem to not stick exactly to the spec. So expect some thing to take a little extra effort to get them there.
 
-A custom handlebar function to split comma separated tags is available, as Obsidian expect tags as a list in its properties. The function is called `splitTags`, and could be used as this in a template: `{{splitTags keywords}}`.
-
 You can also add `{{{json}}}` for the raw json in the template if you like.
+
+#### Custom handlebar functions
+
+`splitTags`  
+Split comma separated tags. Obsidian expect tags as a list in its properties.
+
+```
+tags:
+{{splitTags keywords}}
+```
+
+`prettyTime`
+Fix the ugly PT1H30M string to a prettier 1h 30m formatting
+
+```
+Prep Time: {{prettyTime prepTime}}
+Cook Time: {{prettyTime cookTime}}
+Total Time: {{prettyTime totalTime}}
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,23 +35,29 @@ tags:
 {{splitTags keywords}}
 ```
 
-`prettyTime`
-Fix the ugly PT1H30M string to a prettier 1h 30m formatting
+`magicTime`
+Attempts to handle anything included with time and date.  
+Change the ugly PT1H30M string to a prettier 1h 30min formatting.  
+Insert or reformat existing timestamps using any masks available at [dateformat](https://www.npmjs.com/package/dateformat), defaults to `yyyy-mm-dd HH:MM`.
 
 ```
-Prep Time: {{prettyTime prepTime}}
-Cook Time: {{prettyTime cookTime}}
-Total Time: {{prettyTime totalTime}}
+DateSaved: {{magicTime}}
+DateSaved2: {{magicTime "dd-mm-yyyy HH:MM"}}
+CookTime: {{magicTime cookTime}}
+TotalTime: {{magicTime totalTime}}
+DatePublished1: {{magicTime datePublished}}
+DatePublished2: {{magicTime datePublished "dd-mm-yyyy HH:MM"}}
 ```
 
-`savedAt`
-Timestamp when recipe is saved to Obsidian. Supports masks available at [dateformat](https://www.npmjs.com/package/dateformat).
-Defaults to `yyyy-mm-dd HH:MM`
+Would return something like
 
 ```
-Saved: {{savedAt}}
-Time: {{savedAt "HH:MM"}}
-Date: {{savedAt "yyyy-mm-dd"}}
+DateSaved: 2024-04-13 20:10
+DateSaved2: 13-04-2024 20:10
+CookTime: 15m
+TotalTime: 1h 5m
+DatePublished1: 2017-07-27 00:14
+DatePublished2: 27-07-2017 00:14
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	},
 	"dependencies": {
 		"cheerio": "^1.0.0-rc.12",
+		"dateformat": "^5.0.3",
 		"file-type": "^19.0.0",
 		"handlebars": "^4.7.8",
 		"schema-dts": "^1.1.2"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,8 @@ export const CMD_INSERT_RECIPE = "cmd-insert-recipe";
 /* ---------------------------- DEFAULT TEMPLATE ---------------------------- */
 
 export const DEFAULT_TEMPLATE = `---
-tags: recipe 
+tags: 
+- recipe 
 created: {{datePublished}}
 author: {{author.name}}
 url: {{url}} 

--- a/src/main.ts
+++ b/src/main.ts
@@ -179,6 +179,18 @@ export default class RecipeGrabber extends Plugin {
 			return tagString;
 		});
 
+		handlebars.registerHelper("prettyTime", function (thetime) {
+			if (thetime) {
+				return thetime
+					.trim()
+					.replace("PT", "")
+					.replace("H", "h ")
+					.replace("M", "m ")
+					.replace("S", "s ");
+			}
+			return "";
+		});
+
 		const markdown = handlebars.compile(this.settings.recipeTemplate);
 		try {
 			const recipes = await this.fetchRecipes(url);

--- a/src/main.ts
+++ b/src/main.ts
@@ -377,7 +377,7 @@ export default class RecipeGrabber extends Plugin {
 			return false;
 		}
 		const subDir = filename;
-		if (!isNaN(imgNum)) {
+		if (imgNum !== false) {
 			filename += "_" + imgNum.toString();
 		}
 		try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -183,27 +183,47 @@ export default class RecipeGrabber extends Plugin {
 			return tagString;
 		});
 
-		// Prettify time
-		handlebars.registerHelper("prettyTime", function (thetime) {
-			if (!thetime || typeof thetime != "string") {
+		handlebars.registerHelper("magicTime", function (arg1, arg2) {
+			if (typeof arg1 === "undefined") {
+				// catch undefined / empty
 				return "";
 			}
-			return thetime
-				.trim()
-				.replace("PT", "")
-				.replace("H", "h ")
-				.replace("M", "m ")
-				.replace("S", "s ");
-			}
-			return "";
-		});
-
-		// Formattable timestamp when saved
-		handlebars.registerHelper("savedAt", function (savedFormat) {
-			if (!savedFormat || typeof savedFormat != "string") {
+			// Handlebars appends an ubject to the arguments
+			if (arguments.length == 1) {
+				// magicTime
 				return dateFormat(new Date(), "yyyy-mm-dd HH:MM");
+			} else if (arguments.length == 2) {
+				if (new Date(arg1) == "Invalid Date") {
+					if (arg1.trim().startsWith("PT")) {
+						// magicTime PT1H50M
+						return arg1
+							.trim()
+							.replace("PT", "")
+							.replace("H", "h ")
+							.replace("M", "m ")
+							.replace("S", "s ");
+					}
+					try {
+						// magicTime "dd-mm-yyyy HH:MM"
+						let returnDate = dateFormat(new Date(), arg1);
+						return returnDate;
+					} catch (error) {
+						return "";
+					}
+				}
+				return dateFormat(new Date(arg1), "yyyy-mm-dd HH:MM");
+				// magicTime datePublished
+			} else if (arguments.length == 3) {
+				// magicTime datePublished "dd-mm-yyyy HH:MM"
+				if (new Date(arg1) == "Invalid Date") {
+					// Invalid input
+					return "Error in template or source";
+				}
+				return dateFormat(new Date(arg1), arg2);
+			} else {
+				// Unexpected amount of arguments
+				return "Error in template";
 			}
-			return dateFormat(new Date(), savedFormat);
 		});
 
 		const markdown = handlebars.compile(this.settings.recipeTemplate);

--- a/src/main.ts
+++ b/src/main.ts
@@ -402,6 +402,10 @@ export default class RecipeGrabber extends Plugin {
 			} else {
 				path = `${normalizePath(this.settings.imgFolder)}/${filename}.${type.ext}`;
 			}
+			const file = app.vault.getAbstractFileByPath(path);
+			if (file && file instanceof TFile) {
+				return file;
+			}
 			const imgPath = await app.vault.createBinary(path, res.arrayBuffer);
 			return imgPath;
 		} catch (err) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import { fileTypeFromBuffer } from "file-type";
 import * as c from "./constants";
 import * as settings from "./settings";
 import { LoadRecipeModal } from "./modal-load-recipe";
+import dateFormat, { masks } from "dateformat";
 
 export default class RecipeGrabber extends Plugin {
 	settings: settings.PluginSettings;
@@ -179,6 +180,7 @@ export default class RecipeGrabber extends Plugin {
 			return tagString;
 		});
 
+		// Prettify time
 		handlebars.registerHelper("prettyTime", function (thetime) {
 			if (thetime) {
 				return thetime
@@ -189,6 +191,14 @@ export default class RecipeGrabber extends Plugin {
 					.replace("S", "s ");
 			}
 			return "";
+		});
+
+		// Formattable timestamp when saved
+		handlebars.registerHelper("savedAt", function (savedFormat) {
+			if (!savedFormat || typeof savedFormat != "string") {
+				return dateFormat(new Date(), "yyyy-mm-dd HH:MM");
+			}
+			return dateFormat(new Date(), savedFormat);
 		});
 
 		const markdown = handlebars.compile(this.settings.recipeTemplate);

--- a/src/main.ts
+++ b/src/main.ts
@@ -172,6 +172,9 @@ export default class RecipeGrabber extends Plugin {
 	private addRecipeToMarkdown = async (url: string): Promise<void> => {
 		// Add a handlebar function to split comma separated tags into the obsidian expected array/list
 		handlebars.registerHelper("splitTags", function (tags) {
+			if (!tags || typeof tags != "string") {
+				return "";
+			}
 			var tagsArray = tags.split(",");
 			var tagString = "";
 			for (const tag of tagsArray) {
@@ -182,13 +185,15 @@ export default class RecipeGrabber extends Plugin {
 
 		// Prettify time
 		handlebars.registerHelper("prettyTime", function (thetime) {
-			if (thetime) {
-				return thetime
-					.trim()
-					.replace("PT", "")
-					.replace("H", "h ")
-					.replace("M", "m ")
-					.replace("S", "s ");
+			if (!thetime || typeof thetime != "string") {
+				return "";
+			}
+			return thetime
+				.trim()
+				.replace("PT", "")
+				.replace("H", "h ")
+				.replace("M", "m ")
+				.replace("S", "s ");
 			}
 			return "";
 		});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,6 +7,7 @@ export interface PluginSettings {
 	saveInActiveFile: boolean;
 	imgFolder: string;
 	saveImg: boolean;
+	saveImgSubdir: boolean;
 	recipeTemplate: string;
 	unescapeHtml: boolean;
 	debug: boolean;
@@ -17,6 +18,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
 	saveInActiveFile: false,
 	imgFolder: "",
 	saveImg: false,
+	saveImgSubdir: false,
 	recipeTemplate: c.DEFAULT_TEMPLATE,
 	unescapeHtml: false,
 	debug: false,
@@ -38,7 +40,7 @@ export class SettingsTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Recipe save folder")
 			.setDesc(
-				"Default recipe import location. If empty, recipe will be imported in the Vault root."
+				"Default recipe import location. If empty, recipe will be imported in the Vault root.",
 			)
 			.addText((text) => {
 				text.setPlaceholder("eg: Recipes")
@@ -52,7 +54,7 @@ export class SettingsTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Save in currently opened file")
 			.setDesc(
-				"Imports the recipe into an active document. if no active document, the above save folder setting will apply."
+				"Imports the recipe into an active document. if no active document, the above save folder setting will apply.",
 			)
 			.addToggle((toggle) => {
 				toggle
@@ -70,25 +72,42 @@ export class SettingsTab extends PluginSettingTab {
 				href: "https://github.com/seethroughdev/obsidian-recipe-grabber#settings",
 				text: "README",
 			}),
-			" for more info."
+			" for more info.",
 		);
-		
+
 		new Setting(containerEl)
 			.setName("Save images")
 			.setDesc(saveImgDescription)
 			.addText((text) => {
-				 text.setPlaceholder("eg: Recipes/RecipeImages")
+				text.setPlaceholder("eg: Recipes/RecipeImages")
 					.setValue(this.plugin.settings.imgFolder)
 					.onChange(async (value) => {
 						this.plugin.settings.imgFolder = value.trim();
 						await this.plugin.saveSettings();
-					})
-				})
+					});
+			})
 			.addToggle((toggle) => {
 				toggle
 					.setValue(this.plugin.settings.saveImg)
 					.onChange(async (value) => {
 						this.plugin.settings.saveImg = value;
+						await this.plugin.saveSettings();
+					});
+			});
+
+		const saveImgSubdirDescription = document.createDocumentFragment();
+		saveImgSubdirDescription.append(
+			"Create a subdirectory for each recipe to store images. A parent directory needs to be set above.",
+		);
+
+		new Setting(containerEl)
+			.setName("Save images in subdirectories")
+			.setDesc(saveImgSubdirDescription)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.saveImgSubdir)
+					.onChange(async (value) => {
+						this.plugin.settings.saveImgSubdir = value;
 						await this.plugin.saveSettings();
 					});
 			});
@@ -100,7 +119,7 @@ export class SettingsTab extends PluginSettingTab {
 				href: "https://github.com/seethroughdev/obsidian-recipe-grabber#custom-templating",
 				text: "README",
 			}),
-			" for more info."
+			" for more info.",
 		);
 
 		new Setting(containerEl)
@@ -117,23 +136,23 @@ export class SettingsTab extends PluginSettingTab {
 							c.DEFAULT_TEMPLATE;
 						await this.plugin.saveSettings();
 						this.display();
-					})
+					}),
 			)
 			.addTextArea((text) => {
 				text.setValue(this.plugin.settings.recipeTemplate).onChange(
 					async (value) => {
 						this.plugin.settings.recipeTemplate = value;
 						await this.plugin.saveSettings();
-					}
+					},
 				);
 			});
 
 		new Setting(containerEl)
 			.setName(
-				"Prevent escaping HTML (only do this if you know what you're doing)"
+				"Prevent escaping HTML (only do this if you know what you're doing)",
 			)
 			.setDesc(
-				"This will tell the templating engine to attempt to unescape the HTML in case you want symbols rendered in the edit mode of your recipes."
+				"This will tell the templating engine to attempt to unescape the HTML in case you want symbols rendered in the edit mode of your recipes.",
 			)
 			.addToggle((toggle) => {
 				toggle


### PR DESCRIPTION
Made changes to avoid [issues ](https://github.com/lachholden/obsidian-recipe-view/issues/16#issuecomment-1925877442)with properties when using [obsidian-recipe-view](https://github.com/lachholden/obsidian-recipe-view).  

Improved image grabbing #10
- Spaces converted to dashes to avoid paths to be broken
- Download images where available in the steps in recipeInstructions
- Option to store images in per-recipe subdirectories
- Use already downloaded images if they exists, typically needed when re-downloading a recipe

Added handlebar functions for
- splitTags: Split comma separated tags. Obsidian expect tags as a list in its properties.
- prettyTime: Fix the ugly PT1H30M string to a prettier 1h 30m formatting
- savedAt: Date/Timestamp when saved #16