### PR TITLE
fix: append to file if its open in reading mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "recipe-grabber",
-	"version": "0.18.0",
+	"version": "0.19.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "recipe-grabber",
-			"version": "0.18.0",
+			"version": "0.19.0",
 			"license": "MIT",
 			"dependencies": {
 				"cheerio": "^1.0.0-rc.12",

--- a/src/main.ts
+++ b/src/main.ts
@@ -359,14 +359,20 @@ export default class RecipeGrabber extends Plugin {
 				// notice instead of just passing the recipe into markdown, we are
 				// adding a key called 'json'. This is so we can see the raw json in the
 				// template if a user wants it.
-				view?.editor.replaceSelection(
-					markdown({
-						...recipe,
-						json: JSON.stringify(recipe, null, 2),
-					}),
-				);
+				const md = markdown({
+					...recipe,
+					json: JSON.stringify(recipe, null, 2),
+				});
+				if (view.getMode() === "source") {
+					view.editor.replaceSelection(md);
+				} else {
+					await this.app.vault.append(view.file, md);
+				}
 			}
 		} catch (error) {
+			if (this.settings.debug) {
+				console.error(error);
+			}
 			return;
 		}
 	};


### PR DESCRIPTION
If a file was open in reading mode while trying to grab a recipe (e.g. `Editor > Default view for new tabs` is set to "Reading view"), Recipe Grabber would fail silently and leave the document blank.

This adds a case for this, in which case it simply appends to the file using the Vault API, rather than trying to manipulate the editor itself.

Fixes #29 