### PR TITLE
fix: escape filename characters disallowed on Windows

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -249,7 +249,9 @@ export default class RecipeGrabber extends Plugin {
 				// try and get recipe title
 				const filename =
 					recipes?.length > 0 && recipes?.[0]?.name
-						? recipes[0].name
+						? (recipes[0].name as string)
+								// replace disallowed characters
+								.replace(/"|\*|\\|\/|<|>|:|\?/g, "")
 						: new Date().getTime(); // Generate a unique timestamp
 
 				const path =
@@ -292,11 +294,11 @@ export default class RecipeGrabber extends Plugin {
 				}
 				// this will download the images and replace the json "recipe.image" value with the path of the image file.
 				if (this.settings.saveImg && file) {
-					// replace any whitespace with dashes
-					const filename = (recipe?.name as string)?.replace(
-						/\s+/g,
-						"-",
-					);
+					const filename = (recipe?.name as string)
+						// replace any whitespace with dashes
+						?.replace(/\s+/g, "-")
+						// replace disallowed characters
+						.replace(/"|\*|\\|\/|<|>|:|\?/g, "");
 					if (!filename) {
 						return;
 					}


### PR DESCRIPTION
Had an error come up while trying to grab a recipe with quotes in the title (https://www.cookwell.com/recipe/lamb-pita-smash-burger) on my Windows machine.

```
Error: File name cannot contain any of the following characters: * " \ / < > : | ?
```

I just added a simple regex to filter out these characters completely, and the problem is now gone. This didn't crop up on MacOS (and maybe Linux? haven't tested) due to it being more lax with file names, but I think it's best to apply this for all platforms so that nothing bizarre happens when syncing between different operating systems.