### PR TITLE
Add microdata support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -137,6 +137,45 @@ export default class RecipeGrabber extends Plugin {
       });
     }
 
+    function parseMicrodata(el: cheerio.Element): void {
+      // manually parse the recipe: get all tags with itemprop attribute
+      const recipe: any = {};
+      $(el)
+        .find("[itemprop]")
+        .each((_, item) => {
+          const $item = $(item);
+          const itemprop = $item.attr("itemprop");
+          let value: any;
+          if ($item.is("meta") && ($item.attr("content") || "").trim() !== "") {
+            value = $item.attr("content")?.trim();
+          } else if (
+            $item.is("img") &&
+            ($item.attr("src") || "").trim() !== ""
+          ) {
+            value = $item.attr("src")?.trim();
+          } else {
+            value = $item.text().trim();
+          }
+
+          // handle multiple recipeIngredient and recipeInstructions
+          if (itemprop === "recipeIngredient") {
+            if (!Array.isArray(recipe[itemprop])) {
+              recipe[itemprop] = [];
+            }
+            recipe[itemprop].push(value);
+          } else if (itemprop === "recipeInstructions") {
+            if (!Array.isArray(recipe[itemprop])) {
+              recipe[itemprop] = [];
+            }
+            recipe[itemprop].push({ text: value });
+          } else {
+            recipe[itemprop as string] = value;
+          }
+        });
+      normalizeSchema(recipe);
+      recipes.push(recipe);
+    }
+
     // parse the dom of the page and look for any schema.org/Recipe
     $('script[type="application/ld+json"]').each((i, el) => {
       const content = $(el).text()?.trim();
@@ -146,6 +185,14 @@ export default class RecipeGrabber extends Plugin {
       const data = Array.isArray(json) ? json : [json];
       handleSchemas(data);
     });
+
+    if (recipes?.length === 0) {
+      $(
+        '[itemtype="http://schema.org/Recipe"], [itemtype="https://schema.org/Recipe"]',
+      ).each((_, el) => {
+        parseMicrodata(el);
+      });
+    }
 
     return recipes;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,8 +112,6 @@ export default class RecipeGrabber extends Plugin {
       if (typeof json.recipeIngredient === "string") {
         json.recipeIngredient = [json.recipeIngredient];
       }
-
-      recipes.push(json);
     };
 
     /**
@@ -133,6 +131,7 @@ export default class RecipeGrabber extends Plugin {
               : schema?.["@type"] === "Recipe"
           ) {
             normalizeSchema(schema);
+            recipes.push(schema);
           }
         }
       });
@@ -155,6 +154,14 @@ export default class RecipeGrabber extends Plugin {
    * This function handles all the templating of the recipes
    */
   private addRecipeToMarkdown = async (url: string): Promise<void> => {
+    handlebars.registerHelper("tagify", function (arg1) {
+      if (typeof arg1 != "string") {
+        return "";
+      }
+      // replace all whitespace with _ and lowercase
+      return arg1.replace(/\s+/g, "_").toLowerCase();
+    });
+
     // Add a handlebar function to split comma separated tags into the obsidian expected array/list
     handlebars.registerHelper("splitTags", function (tags) {
       if (!tags || typeof tags != "string") {


### PR DESCRIPTION
This is basically the dumb version of #23 :)

The "tagify" helper admittedly has nothing to do with this, but I needed it and hope it may be helpful to others as well; after all, users can't register their own handlebars helpers without modifying the plugin source, right?

Test sites I used:
- https://www.zuckerjagdwurst.com/de/rezepte/vegane-double-chocolate-cheesecake-muffins
- https://www.closetcooking.com/mexican-stuffed-peppers/ [^1]

PS: In the meantime I discovered that obsidian now has it's own recipe-grabber, which supports structured Schema.org data, but seems to also lack Microdata support. So I also added a ticket there [^2].

[^1]: see #40
[^2]: obsidianmd/obsidian-clipper#664